### PR TITLE
Fix the flicker problem on iOS (Safari)

### DIFF
--- a/src/Resources/public/framework/scss/styles/_tiny-slider.scss
+++ b/src/Resources/public/framework/scss/styles/_tiny-slider.scss
@@ -22,6 +22,7 @@
   .tns-item {
     -webkit-user-select: none;
     user-select: none;
+    -webkit-transform: translate3d(0, 0, 0);
 
     img {
       -webkit-user-drag: none;


### PR DESCRIPTION
In Safari, the TinySlider has a bug that when swiping images flicker or are displayed only half. The problem can be fixed with the attached change. 
In the core of the TinySlider the whole thing was not fixed until today, therefore the fix here. 

There are several open issues.
Example: https://github.com/ganlanyuan/tiny-slider/issues/683